### PR TITLE
Do not flag the same GA at two Vs as a duplicate

### DIFF
--- a/src/it/issue-7/green-eggs/pom.xml
+++ b/src/it/issue-7/green-eggs/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.codehaus.mojo.extra-enforcer-rules.it</groupId>
+		<artifactId>issue-7</artifactId>
+		<version>0.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>green-eggs</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.6</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/src/it/issue-7/green-eggs/src/main/resources/placeholder.txt
+++ b/src/it/issue-7/green-eggs/src/main/resources/placeholder.txt
@@ -1,0 +1,1 @@
+I would not eat them on a boat.

--- a/src/it/issue-7/ham/pom.xml
+++ b/src/it/issue-7/ham/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.codehaus.mojo.extra-enforcer-rules.it</groupId>
+		<artifactId>issue-7</artifactId>
+		<version>0.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>ham</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.2</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/src/it/issue-7/ham/src/main/resources/placeholder.txt
+++ b/src/it/issue-7/ham/src/main/resources/placeholder.txt
@@ -1,0 +1,1 @@
+I would not eat them with a goat.

--- a/src/it/issue-7/invoker.properties
+++ b/src/it/issue-7/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = package
+invoker.buildResult = success

--- a/src/it/issue-7/pom.xml
+++ b/src/it/issue-7/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.extra-enforcer-rules.it</groupId>
+  <artifactId>issue-7</artifactId>
+	<version>0.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+  <name>Multiple versions test</name>
+
+	<modules>
+		<module>green-eggs</module>
+		<module>ham</module>
+		<module>sam-i-am</module>
+	</modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@enforcerPluginVersion@</version>
+        <dependencies>
+          <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>@project.artifactId@</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+				<executions>
+					<execution>
+						<id>enforce-rules</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+        <configuration>
+          <rules>
+            <banDuplicateClasses/>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/issue-7/sam-i-am/pom.xml
+++ b/src/it/issue-7/sam-i-am/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.codehaus.mojo.extra-enforcer-rules.it</groupId>
+		<artifactId>issue-7</artifactId>
+		<version>0.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>sam-i-am</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>green-eggs</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>ham</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/src/it/issue-7/sam-i-am/src/main/resources/placeholder.txt
+++ b/src/it/issue-7/sam-i-am/src/main/resources/placeholder.txt
@@ -1,0 +1,1 @@
+I do not like green eggs and ham!

--- a/src/main/java/org/apache/maven/plugins/enforcer/AbstractResolveDependencies.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/AbstractResolveDependencies.java
@@ -122,17 +122,20 @@ public abstract class AbstractResolveDependencies implements EnforcerRule
             {
                 try
                 {
-                    Artifact artifact = depNode.getArtifact();
-    
-                    resolver.resolve( artifact, remoteRepositories, localRepository );
-                    
-                    children.add( artifact );
-    
-                    Set<Artifact> subNodes = getAllDescendants( depNode );
-                    
-                    if( subNodes != null )
+                    if ( depNode.getState() == DependencyNode.INCLUDED )
                     {
-                        children.addAll(subNodes);
+                        Artifact artifact = depNode.getArtifact();
+
+                        resolver.resolve( artifact, remoteRepositories, localRepository );
+
+                        children.add( artifact );
+
+                        Set<Artifact> subNodes = getAllDescendants( depNode );
+
+                        if( subNodes != null )
+                        {
+                            children.addAll(subNodes);
+                        }
                     }
                 }
                 catch ( ArtifactResolutionException e )


### PR DESCRIPTION
When a project's dependency tree includes multiple versions of the same artifact (i.e., the same GA with different Vs), the banDuplicateClasses rule should not fail the build, since Maven will ultimately resolve that GA to a single V in the final product.