### PR TITLE
Fix spelling of project.build.sourceEncoding in documentation

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/RequireEncoding.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequireEncoding.java
@@ -29,7 +29,7 @@ public class RequireEncoding
     implements EnforcerRule
 {
     /**
-     * Validate files match this encoding. If not specified then default to ${project.builder.sourceEncoding}.
+     * Validate files match this encoding. If not specified then default to ${project.build.sourceEncoding}.
      */
     private String encoding = "";
 

--- a/src/site/apt/requireEncoding.apt.vm
+++ b/src/site/apt/requireEncoding.apt.vm
@@ -32,7 +32,7 @@ Require Encoding
 
   The following parameters are supported by this rule:
 
-   * <<<encoding>>> - Required encoding. Default value <<<$\{project.builder.sourceEncoding\}>>>.
+   * <<<encoding>>> - Required encoding. Default value <<<$\{project.build.sourceEncoding\}>>>.
    
    * <<<includes>>> - List of files to include, separated by comma or pipe
 


### PR DESCRIPTION
Small typo in the documentation. Name of property in code is correct.