### PR TITLE
Handle corrupted jars in EnforceBytecodeVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
           <showErrors>true</showErrors>
           <streamLogs>true</streamLogs>
           <settingsFile>src/it/settings.xml</settingsFile>
+          <preBuildHookScript>setup</preBuildHookScript>
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
           <filterProperties>

--- a/src/it/enforce-bytecode-version-with-corrupted-jar/invoker.properties
+++ b/src/it/enforce-bytecode-version-with-corrupted-jar/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = enforcer:enforce install
+invoker.mavenOpts = -ea
+invoker.buildResult = failure

--- a/src/it/enforce-bytecode-version-with-corrupted-jar/pom.xml
+++ b/src/it/enforce-bytecode-version-with-corrupted-jar/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@enforcerPluginVersion@</version>
+				<dependencies>
+					<dependency>
+						<groupId>@project.groupId@</groupId>
+						<artifactId>@project.artifactId@</artifactId>
+						<version>@project.version@</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJavaMajorVersionNumber>49</maxJavaMajorVersionNumber>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/it/enforce-bytecode-version-with-corrupted-jar/setup.groovy
+++ b/src/it/enforce-bytecode-version-with-corrupted-jar/setup.groovy
@@ -1,0 +1,7 @@
+File file = new File( localRepositoryPath, "org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar" );
+if (file.exists()) {
+    file.delete();
+    file.createNewFile();
+}
+
+return true

--- a/src/it/enforce-bytecode-version-with-corrupted-jar/verify.groovy
+++ b/src/it/enforce-bytecode-version-with-corrupted-jar/verify.groovy
@@ -1,0 +1,15 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+def text = file.getText("utf-8");
+
+try {
+    assert text.find(/IOException while reading .*org\/hibernate\/hibernate-annotations\/3.4.0.GA\/hibernate-annotations-3.4.0.GA.jar/)
+} finally {
+    File jar = new File( localRepositoryPath, "org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar" );
+    if (jar.exists()) {
+        jar.delete();
+    }
+}
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -308,7 +308,7 @@ public class EnforceBytecodeVersion
         }
         catch ( IOException e )
         {
-            throw new EnforcerRuleException( "IOException while reading " + jarFile.getName(), e );
+            throw new EnforcerRuleException( "IOException while reading " + f.getAbsolutePath(), e );
         }
         finally
         {

--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -308,7 +308,7 @@ public class EnforceBytecodeVersion
         }
         catch ( IOException e )
         {
-            throw new EnforcerRuleException( "IOException while reading " + f.getAbsolutePath(), e );
+            throw new EnforcerRuleException( "IOException while reading " + f, e );
         }
         finally
         {


### PR DESCRIPTION
if you have a corrupted jar for a dependency somewhere in a local repo,
the rule just issued a NPE with no hint on which file had a problem.

```
Caused by: java.lang.NullPointerException: null
	at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.isBadArtifact(EnforceBytecodeVersion.java:311) ~[na:na]
	at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.checkDependencies(EnforceBytecodeVersion.java:220) ~[na:na]
	at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.handleArtifacts(EnforceBytecodeVersion.java:146) ~[na:na]
	at org.apache.maven.plugins.enforcer.AbstractResolveDependencies.execute(AbstractResolveDependencies.java:77) ~[na:na]
	at org.apache.maven.plugins.enforcer.EnforceMojo.execute(EnforceMojo.java:193) ~[na:na]
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134) ~[maven-core-3.3.9.jar:3.3.9]
	... 21 common frames omitted
```

The problem is an IOException can be thrown when creating a JarFile if the file is corrupt.

May be related to https://github.com/mojohaus/extra-enforcer-rules/issues/10 but can't really tell since the build is gone.