### PR TITLE
Add property 'checkExclusions' to BanCircularDependencies.

### DIFF
--- a/src/it/circular-exclusions/invoker.properties
+++ b/src/it/circular-exclusions/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=enforcer:enforce
+invoker.buildResult = failure
+invoker.maven.version = 3.0+

--- a/src/it/circular-exclusions/pom.xml
+++ b/src/it/circular-exclusions/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.slf4j</groupId>
+  <artifactId>slf4j-api</artifactId>
+  <version>1.6.1</version>
+  <name>CircularDependencies test</name>
+
+<dependencies>
+    <!-- if commons-logging had slf4j-api in the dependency tree,
+		it would have been able to get around the rule with this exclusion -->
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.1</version>
+	  <exclusions>
+	    <exclusion>
+		  <groupId>org.slf4j</groupId>
+		  <artifactId>slf4j-api</artifactId>
+		</exclusion>
+	  </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@enforcerPluginVersion@</version>
+        <dependencies>
+          <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>@project.artifactId@</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <rules>
+            <banCircularDependencies>
+				<checkExclusions>true</checkExclusions>
+            </banCircularDependencies>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/main/java/org/apache/maven/plugins/enforcer/BanCircularDependencies.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/BanCircularDependencies.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.enforcer;
  */
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -28,6 +29,8 @@ import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.execution.RuntimeInformation;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
@@ -48,6 +51,12 @@ public class BanCircularDependencies
     private transient DependencyGraphBuilder graphBuilder;
     
     private String message;
+
+	/**
+     * If {@code false} then the rule will only check the dependency hierarchy.
+     * If {@code true} then the rule will also verify there are no exclusions used to get around the rule.
+     */
+    private boolean checkExclusions;    
     
     /**
      * {@inheritDoc}
@@ -94,6 +103,24 @@ public class BanCircularDependencies
                         {
                             StringBuilder buf = new StringBuilder( getErrorMessage() );
                             buf.append( "\n  " ).append( artifact.getGroupId() ).append( ":" ).append( artifact.getArtifactId() ).append( "\n " );
+                            throw new EnforcerRuleException( buf.toString() );
+                        }
+                    }
+                }
+            }
+            if( checkExclusions ) 
+            {
+                List<Dependency> dependencies = project.getDependencies();
+                for( Dependency dependency : dependencies ) 
+                {
+                    List<Exclusion> exclusions = dependency.getExclusions();
+                    for(Exclusion exclusion: exclusions) 
+                    {
+                        if(exclusion.getGroupId().equals(project.getGroupId()) &&
+                                exclusion.getArtifactId().equals(project.getArtifactId())) 
+                        {
+                            StringBuilder buf = new StringBuilder("You are not allowed to break the circular dependency by excluding yourself.  Self exclusion found under dependency "); 
+                            buf.append( "\n  " ).append( dependency.getGroupId() ).append( ":" ).append( dependency.getArtifactId() ).append( "\n " );
                             throw new EnforcerRuleException( buf.toString() );
                         }
                     }

--- a/src/site/apt/banCircularDependencies.apt.vm
+++ b/src/site/apt/banCircularDependencies.apt.vm
@@ -50,7 +50,9 @@ Ban Circular Dependencies
             </goals>
             <configuration>
               <rules>
-                <banCircularDependencies/>
+                <banCircularDependencies>
+                  <checkExclusions>true</checkExclusions>
+                </banCircularDependencies>
               </rules>
               <fail>true</fail>
             </configuration>


### PR DESCRIPTION
If set to true, it will disallow people from using exclusions to break a circular dependency.
