### PR TITLE
JarFile$JarEntryIterator.nextElement can throw IllegalArgumentException

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -331,6 +331,10 @@ public class EnforceBytecodeVersion
         {
             throw new EnforcerRuleException( "IOException while reading " + jarFile.getName(), e );
         }
+        catch ( IllegalArgumentException e )
+        {
+            throw new EnforcerRuleException( "Error while reading " + f, e );
+        }
         finally
         {
             closeQuietly( jarFile );


### PR DESCRIPTION
Similarly to @Vlatombe’s #27, @kshultzCB reported an error which with `-e` displayed a root cause:

```
java.lang.IllegalArgumentException: MALFORMED
	at java.util.zip.ZipCoder.toString(ZipCoder.java:58)
	at java.util.zip.ZipFile.getZipEntry(ZipFile.java:583)
	at java.util.zip.ZipFile.access$900(ZipFile.java:60)
	at java.util.zip.ZipFile$ZipEntryIterator.next(ZipFile.java:539)
	at java.util.zip.ZipFile$ZipEntryIterator.nextElement(ZipFile.java:514)
	at java.util.zip.ZipFile$ZipEntryIterator.nextElement(ZipFile.java:495)
	at java.util.jar.JarFile$JarEntryIterator.next(JarFile.java:257)
	at java.util.jar.JarFile$JarEntryIterator.nextElement(JarFile.java:266)
	at java.util.jar.JarFile$JarEntryIterator.nextElement(JarFile.java:247)
	at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.isBadArtifact(EnforceBytecodeVersion.java:254)
	at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.checkDependencies(EnforceBytecodeVersion.java:220)
	at org.apache.maven.plugins.enforcer.EnforceBytecodeVersion.handleArtifacts(EnforceBytecodeVersion.java:146)
	at org.apache.maven.plugins.enforcer.AbstractResolveDependencies.execute(AbstractResolveDependencies.java:77)
	at org.apache.maven.plugins.enforcer.EnforceMojo.execute(EnforceMojo.java:202)
	at …
```

I am not sure which JAR was broken or how to reproduce, but this patch should at least better report the problem.

@reviewbybees for my colleages