### PR TITLE
Switch to newer dependency graph api for MSHARED-167 fix 

### DIFF
--- a/src/it/enforce-bytecode-version-jdkVersionOption-runtime-scope/invoker.properties
+++ b/src/it/enforce-bytecode-version-jdkVersionOption-runtime-scope/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = enforcer:enforce install
+invoker.buildResult = failure

--- a/src/it/enforce-bytecode-version-jdkVersionOption-runtime-scope/pom.xml
+++ b/src/it/enforce-bytecode-version-jdkVersionOption-runtime-scope/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.batmat.maven.plugins</groupId>
+	<artifactId>enforce-java-version-rule-it-runtime-scope</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>Issue 57: Check runtime scope dependencies</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@enforcerPluginVersion@</version>
+				<dependencies>
+					<dependency>
+						<groupId>@project.groupId@</groupId>
+						<artifactId>@project.artifactId@</artifactId>
+						<version>@project.version@</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.2</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-annotations</artifactId>
+			<version>3.4.0.GA</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/it/enforce-bytecode-version-jdkVersionOption-runtime-scope/verify.groovy
+++ b/src/it/enforce-bytecode-version-jdkVersionOption-runtime-scope/verify.groovy
@@ -1,0 +1,14 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-annotations:jar:3.4.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:ejb3-persistence:jar:1.0.2.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-commons-annotations:jar:3.1.0.GA")
+assert text.contains("Found Banned Dependency: org.hibernate:hibernate-core:jar:3.3.0.SP1")
+assert text.contains("Found Banned Dependency: javax.transaction:jta:jar:1.1")
+assert text.contains("Found Banned Dependency: org.slf4j:slf4j-api:jar:1.4.2")
+assert text.contains("Found Banned Dependency: dom4j:dom4j:jar:1.6.1")
+
+return true;


### PR DESCRIPTION
Uses `DependencyGraphBuilder` instead of `DependencyTreeBuilder` to get the fix for [MSHARED-167](https://issues.apache.org/jira/browse/MSHARED-167)

This  fixes #57.

This also seems to fix an unreported issue where the enforcer rule could give different results when running `mvn validate` vs `mvn verify`, specifically `mvn validate` would not actually analyze all of the dependencies.