### PR TITLE
Add support for Java 11 and test with Maven 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
   - openjdk11
 install:
   - "mvn --show-version --errors --batch-mode validate dependency:go-offline"
-script: "mvn --show-version --errors --batch-mode clean verify site"
+script: "mvn --show-version --errors --batch-mode clean verify"
 cache:
     directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: java
 env:
-  - MAVEN_VERSION=3.0.5
   - MAVEN_VERSION=3.3.9
-  - MAVEN_VERSION=3.5.2
+  - MAVEN_VERSION=3.5.4
+  - MAVEN_VERSION=3.6.0
 jdk:
   - openjdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 install:
-  - "mvn -N io.takari:maven:wrapper -Dmaven=${MAVEN_VERSION}"
-  - "./mvnw --show-version --errors --batch-mode validate dependency:go-offline"
-script: "./mvnw --show-version --errors --batch-mode clean verify site"
+  - "mvn --show-version --errors --batch-mode validate dependency:go-offline"
+script: "mvn --show-version --errors --batch-mode clean verify site"
 cache:
     directories:
     - $HOME/.m2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,17 @@ environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - JAVA_HOME: C:\Program Files\Java\jdk11.0
 
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip', 'C:\maven-bin.zip')
+        (new-object System.Net.WebClient).DownloadFile('https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip', 'C:\maven-bin.zip')
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
 # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=C:\maven\apache-maven-3.3.9\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  - cmd: SET PATH=C:\maven\apache-maven-3.6.0\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
   - cmd: SET MAVEN_OPTS=-Xmx768m
   - cmd: mvn --version
   - cmd: java -version

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <enforcerApiVersion>1.0</enforcerApiVersion>
     <enforcerPluginVersion>1.4</enforcerPluginVersion>
     <maven.version>2.0.9</maven.version>
-    <mojo.java.target>1.5</mojo.java.target>
+    <mojo.java.target>1.6</mojo.java.target>
     <scmpublish.content>target/staging/${project.artifactId}</scmpublish.content>
   </properties>
 
@@ -149,14 +149,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-          <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
-          </configuration>
-        </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,35 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-resport-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -187,6 +216,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <showErrors>true</showErrors>

--- a/src/it/compiling/pom.xml
+++ b/src/it/compiling/pom.xml
@@ -13,6 +13,10 @@
     <module>child-b</module>
   </modules>
 
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
   <build>
     <plugins>
       <plugin>

--- a/src/it/enforce-bytecode-version-with-corrupted-jar/verify.groovy
+++ b/src/it/enforce-bytecode-version-with-corrupted-jar/verify.groovy
@@ -4,7 +4,7 @@ assert file.exists();
 def text = file.getText("utf-8");
 
 try {
-    assert text.find(/IOException while reading .*org\/hibernate\/hibernate-annotations\/3.4.0.GA\/hibernate-annotations-3.4.0.GA.jar/)
+    assert text.find(/IOException while reading .*hibernate-annotations-3.4.0.GA.jar/)
 } finally {
     File jar = new File( localRepositoryPath, "org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar" );
     if (jar.exists()) {

--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -84,6 +84,9 @@ public class EnforceBytecodeVersion
         // Java10
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.10", 54 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "10", 54 );
+
+        // Java11
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "11", 55 );
     }
 
     static String renderVersion( int major, int minor )
@@ -200,7 +203,8 @@ public class EnforceBytecodeVersion
             Integer needle = JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.get( maxJdkVersion );
             if ( needle == null )
             {
-                throw new IllegalArgumentException( "Unknown JDK version given. Should be something like \"1.7\"" );
+                throw new IllegalArgumentException( "Unknown JDK version given. Should be something like " +
+                        "\"1.7\", \"8\", \"11\"" );
             }
             maxJavaMajorVersionNumber = needle;
         }

--- a/src/site/apt/enforceBytecodeVersion.apt.vm
+++ b/src/site/apt/enforceBytecodeVersion.apt.vm
@@ -29,7 +29,7 @@ Enforce Bytecode Version
 
    The following parameters are supported by this rule:
 
-   * maxJdkVersion - the maximum target jdk version in the 1.x form (e.g. 1.6, 1.7, 1.8, 1.9 or 6, 7, 8, 9...) 
+   * maxJdkVersion - the maximum target jdk version in the 1.x form (e.g. 1.6, 1.7, 1.8, 1.9 or 6, 7, 8, 9, 10, 11...)
 
    * maxJavaMajorVersionNumber - an integer indicating the maximum bytecode major version number (cannot be specified if maxJdkVersion is present)
 

--- a/src/test/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersionTest.java
+++ b/src/test/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersionTest.java
@@ -26,6 +26,7 @@ public class EnforceBytecodeVersionTest {
     {
         assertEquals( "JDK 1.5", EnforceBytecodeVersion.renderVersion( 49, 0 ) );
         assertEquals( "JDK 1.7", EnforceBytecodeVersion.renderVersion( 51, 0 ) );
+        assertEquals( "JDK 11", EnforceBytecodeVersion.renderVersion( 55, 0 ) );
         assertEquals( "51.3", EnforceBytecodeVersion.renderVersion( 51, 3 ) );
         assertEquals( "44.0", EnforceBytecodeVersion.renderVersion( 44, 0 ) );
     }


### PR DESCRIPTION
Fixes #61 
Travis CI tests with cobertura reports failed with Java 11 due to not existing tools.jar - probably this plugin should be excluded from the build.