### PR TITLE
Add Java 12 major version number

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -87,6 +87,9 @@ public class EnforceBytecodeVersion
 
         // Java11
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "11", 55 );
+
+        // Java 12
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "12", 56 );
     }
 
     static String renderVersion( int major, int minor )
@@ -204,7 +207,7 @@ public class EnforceBytecodeVersion
             if ( needle == null )
             {
                 throw new IllegalArgumentException( "Unknown JDK version given. Should be something like " +
-                        "\"1.7\", \"8\", \"11\"" );
+                        "\"1.7\", \"8\", \"11\", \"12\"" );
             }
             maxJavaMajorVersionNumber = needle;
         }


### PR DESCRIPTION
JDK 12 is already expected in next March, per https://openjdk.java.net/projects/jdk/12/
So let's "support" it rather sooner than later.

Following up on @oleg-nenashev comment in https://github.com/mojohaus/extra-enforcer-rules/pull/63