### PR TITLE
Correct AppVeyor build for Java 7 and 11

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,15 @@
 version: '{build}'
+image:
+  - Visual Studio 2017
 skip_tags: true
 clone_depth: 10
 environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - JAVA_HOME: C:\Program Files\Java\jdk11.0
+    - JAVA_HOME: C:\Program Files\Java\jdk11
 
-install:
-  - ps: |
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip', 'C:\maven-bin.zip')
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-      }
-# Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=C:\maven\apache-maven-3.6.0\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
-  - cmd: SET MAVEN_OPTS=-Xmx768m
-  - cmd: mvn --version
-  - cmd: java -version
 build_script:
-  - mvn -B clean verify
+  - mvn -B -V clean verify -Dhttps.protocols=TLSv1.2
 cache:
   - C:\Users\appveyor\.m2

--- a/pom.xml
+++ b/pom.xml
@@ -154,15 +154,6 @@
           <version>2.22.1</version>
         </plugin>
         <plugin>
-          <artifactId>maven-surefire-resport-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.7</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>
         </plugin>
@@ -217,6 +208,10 @@
           <preBuildHookScript>setup</preBuildHookScript>
           <postBuildHookScript>verify</postBuildHookScript>
           <addTestClassPath>true</addTestClassPath>
+          <properties>
+            <!-- e.g. ensure that Java7 picks up TLSv1.2 when connecting with Central -->
+            <https.protocols>TLSv1.2</https.protocols>
+          </properties>
           <filterProperties>
             <enforcerPluginVersion>${enforcerPluginVersion}</enforcerPluginVersion>
           </filterProperties>
@@ -242,7 +237,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>1.10</version>
+          <version>3.0.1</version>
         </plugin>
       </plugins>
   </reporting>


### PR DESCRIPTION
Simplify build configuration and use default Maven version (3.6) installed on AppVeyor workers

Fixes problem with connection to Central (TLS1.2)

This PR build status: [![build status](https://ci.appveyor.com/api/projects/status/r0f8kk0qg0yjcdhe?svg=true&1)](https://ci.appveyor.com/project/slachiewicz/extra-enforcer-rules)
Master branch status: [![Build Status (for master branch)](https://ci.appveyor.com/api/projects/status/github/mojohaus/extra-enforcer-rules?branch=master&svg=true)](https://ci.appveyor.com/project/khmarbaise/extra-enforcer-rules)

