### PR TITLE
Also support 1.x version schemes

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -75,23 +75,23 @@ public class EnforceBytecodeVersion
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.7", 51 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "7", 51 );
         // Java8
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.8", 52 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "8", 52 );
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.8", 52 );
         // Java9
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.9", 53 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "9", 53 );
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.9", 53 );
 
         // Java10
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.10", 54 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "10", 54 );
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.10", 54 );
 
         // Java11
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.11", 55 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "11", 55 );
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.11", 55 );
 
         // Java 12
-        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.12", 56 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "12", 56 );
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.12", 56 );
     }
 
     static String renderVersion( int major, int minor )

--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -86,9 +86,11 @@ public class EnforceBytecodeVersion
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "10", 54 );
 
         // Java11
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.11", 55 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "11", 55 );
 
         // Java 12
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "1.12", 56 );
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put( "12", 56 );
     }
 

--- a/src/test/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersionTest.java
+++ b/src/test/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersionTest.java
@@ -27,6 +27,7 @@ public class EnforceBytecodeVersionTest {
         assertEquals( "JDK 1.5", EnforceBytecodeVersion.renderVersion( 49, 0 ) );
         assertEquals( "JDK 1.7", EnforceBytecodeVersion.renderVersion( 51, 0 ) );
         assertEquals( "JDK 11", EnforceBytecodeVersion.renderVersion( 55, 0 ) );
+        assertEquals( "JDK 12", EnforceBytecodeVersion.renderVersion( 56, 0 ) );
         assertEquals( "51.3", EnforceBytecodeVersion.renderVersion( 51, 3 ) );
         assertEquals( "44.0", EnforceBytecodeVersion.renderVersion( 44, 0 ) );
     }


### PR DESCRIPTION
Small followup on #63 and #64 

Despite https://openjdk.java.net/jeps/223 officially deprecating 1.x schemes, we should be permissive here to avoid crashes.

For instance, in Jenkins the version in use is `1.${java.level}`.
https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml#L522

So supporting both formats will avoid unnecessary headaches around. We'll see possibly in the future to stop supporting this when the oldest line is >=9 and no more 1.x format can exist.

cc @jenkinsci/java11-support