### PR TITLE
Use maven-wrapper again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ jdk:
   - openjdk11
   - openjdk-ea
 install:
-  - "mvn --show-version --errors --batch-mode validate dependency:go-offline"
-script: "mvn --show-version --errors --batch-mode clean verify"
+  - "mvn -N io.takari:maven:0.4.3:wrapper -Dmaven=${MAVEN_VERSION} -Dhttps.protocols=TLSv1.2"
+  - "./mvnw --show-version --errors --batch-mode validate dependency:go-offline"
+script:
+  - "./mvnw --show-version --errors --batch-mode clean verify"
 cache:
     directories:
     - $HOME/.m2


### PR DESCRIPTION
* Inbetween installation of Maven versions got lost
* This makes CI more useful again by testing variations of JDK and
  Maven.
* Using newest takari Maven wrapper 0.6.1 is not possible because
  it is compiled with target JDK 8