### PR TITLE
Report artifact info

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -272,6 +272,8 @@ public class EnforceBytecodeVersion
             jarFile = new JarFile( f );
             getLog().debug( f.getName() + " => " + f.getPath() );
             byte[] magicAndClassFileVersion = new byte[8];
+            StringBuilder artifactInfo = new StringBuilder();
+            artifactInfo.append( "(" ).append( a.getGroupId() ).append( ":" ).append( a.getArtifactId() ).append( ") " );
             JAR: for ( Enumeration<JarEntry> e = jarFile.entries(); e.hasMoreElements(); )
             {
                 JarEntry entry = e.nextElement();
@@ -324,7 +326,7 @@ public class EnforceBytecodeVersion
                         
                         if ( MODULE_INFO_CLASS.equals( entry.getName() ) ) {
                             if ( major > maxJavaMajorVersionNumber ) {
-                                getLog().warn("Invalid bytecodeVersion for " + MODULE_INFO_CLASS + ": expected "
+                                getLog().warn( artifactInfo + "Invalid bytecodeVersion for " + MODULE_INFO_CLASS + ": expected "
                                         + maxJavaMajorVersionNumber + ", but was " + major);
                             }
                         }
@@ -334,7 +336,7 @@ public class EnforceBytecodeVersion
                             
                             if ( major != expectedMajor )
                             {
-                                getLog().warn( "Invalid bytecodeVersion for " + entry.getName() + ": expected "
+                                getLog().warn( artifactInfo + "Invalid bytecodeVersion for " + entry.getName() + ": expected "
                                                 + expectedMajor + ", but was " + major );
                             }
                         }

--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -323,8 +323,10 @@ public class EnforceBytecodeVersion
                         Matcher matcher = MULTIRELEASE.matcher( entry.getName() );
                         
                         if ( MODULE_INFO_CLASS.equals( entry.getName() ) ) {
-                            getLog().warn( "Invalid bytecodeVersion for " + entry.getName() + ": expected "
-                                            + maxJavaMajorVersionNumber + ", but was " + major);
+                            if ( major > maxJavaMajorVersionNumber ) {
+                                getLog().warn("Invalid bytecodeVersion for " + MODULE_INFO_CLASS + ": expected "
+                                        + maxJavaMajorVersionNumber + ", but was " + major);
+                            }
                         }
                         else if ( matcher.matches() )
                         {


### PR DESCRIPTION
When an error occurs, this information is provided by `handleArtifacts`.

For warnings, the only information is the information provided by the `getLog().warn()` call itself.

Without this change, the following output is common:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) @ acceptance-test-harness ---
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
[WARNING] Invalid bytecodeVersion for module-info.class: expected 52, but was 53
```