### PR TITLE
fixes problematic ICU4J usage of requestEncoding rule

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/RequireEncoding.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequireEncoding.java
@@ -26,8 +26,9 @@ import com.ibm.icu.text.CharsetMatch;
  * @see <a href="https://github.com/ericbn/encoding-enforcer">ericbn/encoding-enforcer</a>
  */
 public class RequireEncoding
-    implements EnforcerRule
+        implements EnforcerRule
 {
+
     /**
      * Validate files match this encoding. If not specified then default to ${project.build.sourceEncoding}.
      */
@@ -54,20 +55,20 @@ public class RequireEncoding
     private boolean failFast = true;
 
     public void execute( EnforcerRuleHelper helper )
-        throws EnforcerRuleException
+            throws EnforcerRuleException
     {
         try
         {
             if ( StringUtils.isBlank( encoding ) )
             {
-                encoding = (String) helper.evaluate( "${project.build.sourceEncoding}" );
+                encoding = ( String ) helper.evaluate( "${project.build.sourceEncoding}" );
             }
             Log log = helper.getLog();
             if ( encoding.equals( StandardCharsets.US_ASCII.name() ) )
             {
                 log.warn( "Encoding US-ASCII is hard to detect. Use UTF-8 or ISO-8859-1" );
             }
-            String basedir = (String) helper.evaluate( "${basedir}" );
+            String basedir = ( String ) helper.evaluate( "${basedir}" );
             DirectoryScanner ds = new DirectoryScanner();
             ds.setBasedir( basedir );
             if ( StringUtils.isNotBlank( includes ) )
@@ -119,7 +120,7 @@ public class RequireEncoding
     }
 
     protected String getEncoding( String requiredEncoding, File file, Log log )
-        throws IOException
+            throws IOException
     {
         FileInputStream fis = null;
         try
@@ -135,6 +136,13 @@ public class RequireEncoding
             }
             else
             {
+                for ( CharsetMatch match : charsets )
+                {
+                    if ( match.getName().equals( requiredEncoding ) )
+                    {
+                        return requiredEncoding;
+                    }
+                }
                 return charsets[0].getName();
             }
         }

--- a/src/test/java/org/apache/maven/plugins/enforcer/RequireEncodingTest.java
+++ b/src/test/java/org/apache/maven/plugins/enforcer/RequireEncodingTest.java
@@ -26,6 +26,11 @@ public class RequireEncodingTest {
     rule = new RequireEncoding();
   }
 
+    /**
+     * The file ascii.txt is a valid UTF-8 file. There are no special or control characters that are not representable.
+     *
+     * @throws Exception
+     */
   @Test
     public void successUTF8ForSimpleAscii() throws Exception {
     

--- a/src/test/java/org/apache/maven/plugins/enforcer/RequireEncodingTest.java
+++ b/src/test/java/org/apache/maven/plugins/enforcer/RequireEncodingTest.java
@@ -27,7 +27,7 @@ public class RequireEncodingTest {
   }
 
   @Test
-  public void failUTF8() throws Exception {
+    public void successUTF8ForSimpleAscii() throws Exception {
     
     when(helper.evaluate("${basedir}")).thenReturn(new File("src/test/resources").getAbsolutePath());
     when(helper.evaluate("${project.build.sourceEncoding}")).thenReturn("UTF-8");
@@ -35,7 +35,31 @@ public class RequireEncodingTest {
     
     rule.setIncludes("ascii.txt");
 
-    exception.expect(EnforcerRuleException.class);
-    rule.execute(helper);
-  }
+        rule.execute(helper);
+    }
+
+    @Test
+    public void failUTF8ForIso8591() throws Exception {
+
+        when(helper.evaluate("${basedir}")).thenReturn(new File("src/test/resources").getAbsolutePath());
+        when(helper.evaluate("${project.build.sourceEncoding}")).thenReturn("UTF-8");
+        when(helper.getLog()).thenReturn(mock(Log.class));
+
+        rule.setIncludes("iso88591.txt");
+
+        exception.expect(EnforcerRuleException.class);
+        rule.execute(helper);
+    }
+
+    @Test
+    public void successUTF8() throws Exception {
+
+        when(helper.evaluate("${basedir}")).thenReturn(new File("src/test/resources").getAbsolutePath());
+        when(helper.evaluate("${project.build.sourceEncoding}")).thenReturn("UTF-8");
+        when(helper.getLog()).thenReturn(mock(Log.class));
+
+        rule.setIncludes("utf8.txt");
+
+        rule.execute(helper);
+    }
 }


### PR DESCRIPTION
Look at #77. Only ICU4Js first detected encoding is used. For file that are representable in multiple encodings it is quite unlikely, that the enforcer works as expected.