### PR TITLE
Remove note

### DIFF
--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -50,8 +50,6 @@ Extra Enforcer Rules
 
   []
   
-  <<NOTE: When using the Apache Maven Enforcer Plugin version 1.3 or later, be sure to use at least extra-enforcer-rules 1.0-beta-1>>
-
 * Usage
 
   Instructions on how to use the Extra Enforcer Rules can be found on the {{{./usage.html}usage page}}.


### PR DESCRIPTION
I think it's now safe to assume no one is using enforcer plugin 1.x and is using a release version of these rules.