### PR TITLE
Implement EnforcerRule2 to enable warn level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,18 @@
   </developers>
 
   <properties>
-    <enforcerApiVersion>1.0</enforcerApiVersion>
+    <enforcerApiVersion>1.4.1</enforcerApiVersion>
+    <!--
+        Danger ahead: increasing this to the next patch-level 1.4.1 will
+        fail the following ITs:
+        *  banduplicate-classes-fail-when-not-identical/pom.xml
+        *  enforce-bytecode-version-multirelease/pom.xml
+        *  mojo-1731/pom.xml
+        *  mojo-1744/pom.xml
+        *  mojo-1769/pom.xml
+        *  smokes/pom.xml
+        See https://travis-ci.org/github/mojohaus/extra-enforcer-rules/jobs/702384586
+    -->
     <enforcerPluginVersion>1.4</enforcerPluginVersion>
     <maven.version>2.0.9</maven.version>
     <mojo.java.target>1.6</mojo.java.target>

--- a/src/main/java/org/apache/maven/plugins/enforcer/AbstractMojoHausEnforcerRule.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/AbstractMojoHausEnforcerRule.java
@@ -1,0 +1,40 @@
+package org.apache.maven.plugins.enforcer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.enforcer.rule.api.EnforcerLevel;
+import org.apache.maven.enforcer.rule.api.EnforcerRule2;
+
+abstract class AbstractMojoHausEnforcerRule
+        implements EnforcerRule2
+{
+    private EnforcerLevel level = EnforcerLevel.ERROR;
+
+    @Override
+    public EnforcerLevel getLevel()
+    {
+        return level;
+    }
+
+    public void setLevel( EnforcerLevel level )
+    {
+        this.level = level;
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/enforcer/AbstractRequireRoles.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/AbstractRequireRoles.java
@@ -41,7 +41,7 @@ import org.codehaus.plexus.util.StringUtils;
  * @author Mirko Friedenhagen
  * @since 1.0-alpha-3
  */
-abstract class AbstractRequireRoles<T extends Contributor> implements EnforcerRule
+abstract class AbstractRequireRoles<T extends Contributor> extends AbstractMojoHausEnforcerRule
 {
     /**
      * Specify the required roles as comma separated list.

--- a/src/main/java/org/apache/maven/plugins/enforcer/AbstractResolveDependencies.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/AbstractResolveDependencies.java
@@ -28,7 +28,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
  * @author Robert Scholte
  *
  */
-public abstract class AbstractResolveDependencies implements EnforcerRule
+public abstract class AbstractResolveDependencies extends AbstractMojoHausEnforcerRule
 {
 
     private transient DependencyTreeBuilder treeBuilder;

--- a/src/main/java/org/apache/maven/plugins/enforcer/BanCircularDependencies.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/BanCircularDependencies.java
@@ -42,7 +42,7 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
  * @since 1.0-alpha-4
  */
 public class BanCircularDependencies
-    implements EnforcerRule
+        extends AbstractMojoHausEnforcerRule
 {
     
     private transient DependencyGraphBuilder graphBuilder;

--- a/src/main/java/org/apache/maven/plugins/enforcer/RequireEncoding.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequireEncoding.java
@@ -1,10 +1,7 @@
 package org.apache.maven.plugins.enforcer;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -17,7 +14,6 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.util.DirectoryScanner;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.freebsd.file.FileEncoding;
 
@@ -29,7 +25,7 @@ import org.freebsd.file.FileEncoding;
  * @see <a href="https://github.com/ericbn/encoding-enforcer">ericbn/encoding-enforcer</a>
  */
 public class RequireEncoding
-    implements EnforcerRule
+        extends AbstractMojoHausEnforcerRule
 {
     /**
      * Validate files match this encoding. If not specified then default to ${project.build.sourceEncoding}.

--- a/src/main/java/org/apache/maven/plugins/enforcer/RequireProjectUrl.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequireProjectUrl.java
@@ -34,7 +34,9 @@ import java.util.regex.PatternSyntaxException;
  * 
  * @since 1.0-beta-4
  */
-public class RequireProjectUrl implements EnforcerRule {
+public class RequireProjectUrl
+        extends AbstractMojoHausEnforcerRule
+{
     /**
      * The regex that the url must match. Default is a non-empty URL
      */

--- a/src/main/java/org/apache/maven/plugins/enforcer/RequirePropertyDiverges.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/RequirePropertyDiverges.java
@@ -47,7 +47,8 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  * @author Mirko Friedenhagen
  * @since 1.0-alpha-3
  */
-public class RequirePropertyDiverges implements EnforcerRule
+public class RequirePropertyDiverges
+        extends AbstractMojoHausEnforcerRule
 {
     private String message;
     


### PR DESCRIPTION
* Only the old EnforcerRule interface was implemented.
* So the extra-rules could not be set to warn only.
* Although the rules API version is now 1.4.1, using
  1.4.1 of the enforcer-plugin is not possible, because
  a lot of ITs are failing, then.

Fixes #96