### PR TITLE
Support reactor projects in the BanCircularDependencies rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
-      <version>2.1</version>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/it/circular-reactor-no-cycles/invoker.properties
+++ b/src/it/circular-reactor-no-cycles/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=enforcer:enforce
+invoker.buildResult = success
+invoker.maven.version = 3.0+

--- a/src/it/circular-reactor-no-cycles/module-a/pom.xml
+++ b/src/it/circular-reactor-no-cycles/module-a/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>reactor-project-parent</artifactId>
+    <version>1.6.1</version>
+  </parent>
+
+  <artifactId>module-a</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>module-b</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/circular-reactor-no-cycles/module-b/pom.xml
+++ b/src/it/circular-reactor-no-cycles/module-b/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>reactor-project-parent</artifactId>
+    <version>1.6.1</version>
+  </parent>
+
+  <artifactId>module-b</artifactId>
+</project>

--- a/src/it/circular-reactor-no-cycles/pom.xml
+++ b/src/it/circular-reactor-no-cycles/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>reactor-project-parent</artifactId>
+  <version>1.6.1</version>
+  <name>CircularDependencies reactor test</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>module-a</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>module-b</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@enforcerPluginVersion@</version>
+        <dependencies>
+          <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>@project.artifactId@</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <rules>
+            <banCircularDependencies/>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/circular-reactor-with-cycle/invoker.properties
+++ b/src/it/circular-reactor-with-cycle/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=enforcer:enforce
+invoker.buildResult = failure
+invoker.maven.version = 3.0+

--- a/src/it/circular-reactor-with-cycle/module-a/pom.xml
+++ b/src/it/circular-reactor-with-cycle/module-a/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>reactor-project-parent</artifactId>
+    <version>1.6.1</version>
+  </parent>
+
+  <artifactId>module-a</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>module-b</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/circular-reactor-with-cycle/module-b/pom.xml
+++ b/src/it/circular-reactor-with-cycle/module-b/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>reactor-project-parent</artifactId>
+    <version>1.6.1</version>
+  </parent>
+
+  <artifactId>module-b</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>module-a</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/circular-reactor-with-cycle/pom.xml
+++ b/src/it/circular-reactor-with-cycle/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>reactor-project-parent</artifactId>
+  <version>1.6.1</version>
+  <name>CircularDependencies reactor test</name>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>module-a</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>module-b</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>@enforcerPluginVersion@</version>
+        <dependencies>
+          <dependency>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>@project.artifactId@</artifactId>
+            <version>@project.version@</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <rules>
+            <banCircularDependencies/>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/main/java/org/apache/maven/plugins/enforcer/BanCircularDependencies.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/BanCircularDependencies.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.enforcer;
  */
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -48,7 +49,7 @@ public class BanCircularDependencies
     private transient DependencyGraphBuilder graphBuilder;
     
     private String message;
-    
+
     /**
      * {@inheritDoc}
      */
@@ -79,8 +80,9 @@ public class BanCircularDependencies
         try
         {
             MavenProject project = (MavenProject) helper.evaluate( "${project}" );
-            
-            Set<Artifact> artifacts = getDependenciesToCheck( project );
+            List<MavenProject> reactorProjects = (List<MavenProject>) helper.evaluate( "${reactorProjects}" );
+
+            Set<Artifact> artifacts = getDependenciesToCheck( project, reactorProjects );
 
             if ( artifacts != null )
             {
@@ -128,12 +130,12 @@ public class BanCircularDependencies
         }
     }
     
-    protected Set<Artifact> getDependenciesToCheck( MavenProject project )
+    protected Set<Artifact> getDependenciesToCheck( MavenProject project, final List<MavenProject> reactorProjects )
     {
         Set<Artifact> dependencies = null;
         try
         {
-            DependencyNode node = graphBuilder.buildDependencyGraph( project, null );
+            DependencyNode node = graphBuilder.buildDependencyGraph( project, null, reactorProjects );
             dependencies  = getAllDescendants( node );
         }
         catch ( DependencyGraphBuilderException e )


### PR DESCRIPTION
Prior to this commit, using the BanCircularDependencies rule would fail
if:
  1. the project is a reactor project (i.e. uses build aggregation)
  2. one of the modules depends on another
  3. none of the modules have yet been installed in the local repository

This was unfortunate, as the only solution was to run:
  "mvn install"

And even if you did that, the next time one invokes the enforcer plugin
without installing all modules, you could get false positives/negatives,
as the check would be done on the last installed pom.xml, not the actual
pom.xml from the reactor.