### PR TITLE
Bytecode version of multirelease metadata should be lower or equal to specified version

### DIFF
--- a/src/it/enforce-bytecode-version-multirelease-2/invoker.properties
+++ b/src/it/enforce-bytecode-version-multirelease-2/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = enforcer:enforce
+invoker.buildResult = success

--- a/src/it/enforce-bytecode-version-multirelease-2/pom.xml
+++ b/src/it/enforce-bytecode-version-multirelease-2/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>pim.pam.poum</groupId>
+	<artifactId>smoking</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>@enforcerPluginVersion@</version>
+				<dependencies>
+					<dependency>
+						<groupId>@project.groupId@</groupId>
+						<artifactId>@project.artifactId@</artifactId>
+						<version>@project.version@</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.8</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-jaxb-annotations</artifactId>
+			<version>2.13.0</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/src/it/enforce-bytecode-version-multirelease-2/verify.groovy
+++ b/src/it/enforce-bytecode-version-multirelease-2/verify.groovy
@@ -1,0 +1,9 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+assert text.contains( '[INFO] Adding ignore: module-info' )
+assert !text.contains( '[WARNING] Invalid bytecodeVersion for com.fasterxml.jackson.core:jackson-core:jar:2.13.0:runtime' )
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -351,16 +351,16 @@ public class EnforceBytecodeVersion
                         
                         if ( matcher.matches() )
                         {
-                            Integer expectedMajor = JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.get( matcher.group( 1 ) );
+                            Integer maxExpectedMajor = JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.get( matcher.group( 1 ) );
                             
-                            if (expectedMajor == null) {
+                            if (maxExpectedMajor == null) {
                                 getLog().warn( "Unknown bytecodeVersion for " + a + " : "
-                                                + entry.getName() + ": got " + expectedMajor + " class-file-version" ); 
+                                                + entry.getName() + ": got " + maxExpectedMajor + " class-file-version" );
                             }
-                            else if ( major != expectedMajor )
+                            else if ( major > maxExpectedMajor )
                             {
                                 getLog().warn( "Invalid bytecodeVersion for " + a + " : "
-                                        + entry.getName() + ": expected " + expectedMajor + ", but was " + major );
+                                        + entry.getName() + ": expected lower or equal to " + maxExpectedMajor + ", but was " + major );
                             }
                         }
                         else


### PR DESCRIPTION
This fixes warnings observed in the jenkins project using this rule.

```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (display-info) @ MY_PROJECT ---
[INFO] Ignoring requireUpperBoundDeps in com.google.guava:guava
[INFO] Adding ignore: module-info
[WARNING] Invalid bytecodeVersion for com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.12.1:compile : META-INF/versions/11/module-info.class: expected 55, but was 53
```

The check was exact, it should actually be ensuring the bytecode level is lower or equal to what is specified.

Fixes https://github.com/FasterXML/jackson-modules-base/issues/126