### PR TITLE
Recognize JDK 21 class format

### DIFF
--- a/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
+++ b/src/main/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersion.java
@@ -120,6 +120,9 @@ public class EnforceBytecodeVersion extends AbstractResolveDependencies {
 
         // Java 20
         JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("20", 64);
+
+        // Java 21
+        JDK_TO_MAJOR_VERSION_NUMBER_MAPPING.put("21", 65);
     }
 
     static String renderVersion(int major, int minor) {

--- a/src/test/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersionTest.java
+++ b/src/test/java/org/apache/maven/plugins/enforcer/EnforceBytecodeVersionTest.java
@@ -30,5 +30,6 @@ public class EnforceBytecodeVersionTest {
         assertEquals("JDK 12", EnforceBytecodeVersion.renderVersion(56, 0));
         assertEquals("51.3", EnforceBytecodeVersion.renderVersion(51, 3));
         assertEquals("44.0", EnforceBytecodeVersion.renderVersion(44, 0));
+        assertEquals("JDK 21", EnforceBytecodeVersion.renderVersion(65, 0));
     }
 }


### PR DESCRIPTION
I've verified that this is the only change needed for `EnforceBytecodeVersion` to work properly

Fixes https://github.com/mojohaus/extra-enforcer-rules/issues/261