### PR TITLE
Allow build by Maven 4

### DIFF
--- a/src/it/local-project-repo/pom.xml
+++ b/src/it/local-project-repo/pom.xml
@@ -46,7 +46,10 @@
   <repositories>
     <repository>
       <id>local-project-repo</id>
-      <url>${project.baseUri}local-repo</url>
+      <url>file://${project.basedir}/local-repo</url>
+      <releases>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
- project.baseUri is forbidden in  repository.url
- checksum should be ignored