### PR TITLE
Make parent level configurable for reference value in requirePropertyDiverges

### DIFF
--- a/src/main/java/org/codehaus/mojo/extraenforcer/model/RequirePropertyDiverges.java
+++ b/src/main/java/org/codehaus/mojo/extraenforcer/model/RequirePropertyDiverges.java
@@ -401,7 +401,7 @@ public class RequirePropertyDiverges extends AbstractEnforcerRule {
      * Extracted for easier testability.
      *
      * @param parentReferenceName name of the ParentReference.
-     * @return the ParentReference constant.
+     * @return the ParentReference enum constant.
      * @throws EnforcerRuleException if null or no ParentReference matches (case-insensitively)
      */
     ParentReference getParentReference(String parentReferenceName) throws EnforcerRuleException {

--- a/src/site/apt/requirePropertyDiverges.apt.vm
+++ b/src/site/apt/requirePropertyDiverges.apt.vm
@@ -40,6 +40,14 @@ Require Property Diverges
 
    * <<property>> - name of the property which should diverge. Must be given.
 
+   * <<reference>> - parent level to use as evaluation context for the reference value:
+
+      * DEFINING - the rule-defining POM. Default historical behaviour.
+
+      * PARENT - the direct parent of the current POM. The rule is skipped if the POM has no parent.
+
+      * BASE - the top-most local POM of the project. The rule is skipped if the current POM is the top-most POM.
+
    * <<regex>> - match the property value to a given regular expression.
    When not given, this rule checks that the property in the child does not equal
    the one from the defining ancestor. 
@@ -47,7 +55,7 @@ Require Property Diverges
    []
 
   Note that certain properties (e.g. <<<project.url>>> or <<<project.scm.connection>>>
-  are automatically extended with the child's <<<project.artifactId>>>, so using
+  are automatically extended with the child's <<<project.artifactId>>> (see {{{https://maven.apache.org/ref/current/maven-model-builder/#inheritance-assembly}Inheritance assembly}}), so using
   a regex will help in this case, see sample below.
  
   Another caveat: properties defined in the <<<properties>>> section will be 


### PR DESCRIPTION
Enhancement proposal for rule `requirePropertyDiverges`

As proposed in  #282 to @slawekjaranowski 

Adds a new, optional `<reference>` parameter which can take 3 values:

* DEFINING (current behaviour, default)
* PARENT use direct parent as reference context
* BASE use topmost local POM as reference context

Tests & doc included